### PR TITLE
Use layout template if defined

### DIFF
--- a/app/code/community/Studioforty9/Recaptcha/Block/Explicit.php
+++ b/app/code/community/Studioforty9/Recaptcha/Block/Explicit.php
@@ -183,6 +183,12 @@ class Studioforty9_Recaptcha_Block_Explicit extends Mage_Core_Block_Template
 
     public function getTemplate()
     {
+        $templateFromLayout = parent::getTemplate();
+
+        if ($templateFromLayout) {
+            return $templateFromLayout;
+        }
+
         if ($this->_getHelper()->getVersion() === '3') {
             return 'studioforty9/recaptcha/v3.phtml';
         }

--- a/app/design/frontend/base/default/layout/studioforty9_recaptcha.xml
+++ b/app/design/frontend/base/default/layout/studioforty9_recaptcha.xml
@@ -16,20 +16,20 @@
 
     <contacts_index_index>
         <reference name="contactForm">
-            <block type="studioforty9_recaptcha/explicit" name="studioforty9.recaptcha.explicit" template="studioforty9/recaptcha/explicit.phtml"/>
+            <block type="studioforty9_recaptcha/explicit" name="studioforty9.recaptcha.explicit"/>
         </reference>
     </contacts_index_index>
 
     <review_product_list>
         <reference name="product.review.form">
-            <block type="studioforty9_recaptcha/explicit" name="studioforty9.recaptcha.explicit" template="studioforty9/recaptcha/explicit.phtml"/>
+            <block type="studioforty9_recaptcha/explicit" name="studioforty9.recaptcha.explicit"/>
         </reference>
     </review_product_list>
 
     <customer_account_login>
         <reference name="customer_form_login">
             <block type="core/text_list" name="form.additional.info">
-                <block type="studioforty9_recaptcha/explicit" name="studioforty9.recaptcha.explicit" template="studioforty9/recaptcha/explicit.phtml"/>
+                <block type="studioforty9_recaptcha/explicit" name="studioforty9.recaptcha.explicit"/>
             </block>
         </reference>
     </customer_account_login>
@@ -37,7 +37,7 @@
     <customer_account_forgotpassword>
         <reference name="forgotPassword">
             <block type="core/text_list" name="form.additional.info">
-                <block type="studioforty9_recaptcha/explicit" name="studioforty9.recaptcha.explicit" template="studioforty9/recaptcha/explicit.phtml"/>
+                <block type="studioforty9_recaptcha/explicit" name="studioforty9.recaptcha.explicit"/>
             </block>
         </reference>
     </customer_account_forgotpassword>
@@ -45,14 +45,14 @@
     <customer_account_create>
         <reference name="customer_form_register">
             <block type="core/text_list" name="form.additional.info">
-                <block type="studioforty9_recaptcha/explicit" name="studioforty9.recaptcha.explicit" template="studioforty9/recaptcha/explicit.phtml"/>
+                <block type="studioforty9_recaptcha/explicit" name="studioforty9.recaptcha.explicit"/>
             </block>
         </reference>
     </customer_account_create>
 
     <sendfriend_product_send>
         <reference name="sendfriend.send">
-            <block type="studioforty9_recaptcha/explicit" name="studioforty9.recaptcha.explicit" template="studioforty9/recaptcha/explicit.phtml"/>
+            <block type="studioforty9_recaptcha/explicit" name="studioforty9.recaptcha.explicit"/>
         </reference>
     </sendfriend_product_send>
 


### PR DESCRIPTION
Without this change, if you define a custom template in layout it will not be used. Of course you could simply rewrite the module phtml (explicit.phtm or v3.phtml, depending on recaptcha version) but in this case you should make it clear that passing a template in layout will always be ignored.